### PR TITLE
requests-kerberos 0.14.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,45 +1,47 @@
 {% set name = "requests-kerberos" %}
-{% set version = "0.12.0" %}
+{% set version = "0.14.0" %}
 
 package:
-  name: "{{ name|lower }}"
-  version: "{{ version }}"
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
   sha256: "9d21f15241c53c2ad47e813138b9aee4b9acdd04b82048c4388ade15f40a52fd"
 
 build:
-  number: 3
+  number: 0
+  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
+    - python
     - pip
-    - python
     - setuptools
+    - wheel
   run:
-    - cryptography >=1.3
-    - pykerberos >=1.1.8,<2.0.0  # [not win]
     - python
+    - cryptography >=1.3
+    - pyspnego
     - requests >=1.1.0
-    - winkerberos >=0.5.0  # [win]
 
 test:
   imports:
     - requests_kerberos
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: "https://github.com/requests/requests-kerberos"
-  dev_url: "https://github.com/requests/requests-kerberos"
-  doc_url: "https://pypi.org/project/requests-kerberos/"
-  license: "ISC"
-  license_family: "MIT"
-  license_file: "LICENSE"
-  summary: "A Kerberos authentication handler for python-requests"
+  home: https://github.com/requests/requests-kerberos
+  dev_url: https://github.com/requests/requests-kerberos
+  doc_url: https://pypi.org/project/requests-kerberos/
+  license: ISC
+  license_family: MIT
+  license_file: LICENSE
+  summary: A Kerberos authentication handler for python-requests
   description: |
     Requests is an HTTP library, written in Python, for human beings.
     This library adds optional Kerberos/GSSAPI authentication support

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,13 +6,13 @@ package:
   version: {{ version }}
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: "9d21f15241c53c2ad47e813138b9aee4b9acdd04b82048c4388ade15f40a52fd"
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: cda9d1240ae5392e081869881c8742d0e171fd6a893a7ac0875db2748e966fd1
 
 build:
   number: 0
   noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+  script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
 
 requirements:
   host:
@@ -21,7 +21,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python
+    - python >=3.6
     - cryptography >=1.3
     - pyspnego
     - requests >=1.1.0


### PR DESCRIPTION
Upstream changelog: https://github.com/requests/requests-kerberos/blob/master/HISTORY.rst
Upstream license: https://github.com/requests/requests-kerberos/blob/master/LICENSE
Upstream setup file: https://github.com/requests/requests-kerberos/blob/v0.14.0/setup.py


The package requests-kerberos is mentioned inside the packages:
airflow | python-hdfs | requests-kerberos | sparkmagic |

Actions:
1. Use noarch python
2. Add missing packages
3. Add pip check
4. Update dependencies
5. Fix license, dev_url
6. Update sha256
7. Use python >=3.6 in run

Result:
- all-failed