### PR TITLE
requests-kerberos 0.15.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  skip: true # [py<38]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,17 @@
 {% set name = "requests-kerberos" %}
-{% set version = "0.14.0" %}
+{% set version = "0.15.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: cda9d1240ae5392e081869881c8742d0e171fd6a893a7ac0875db2748e966fd1
+  url: https://github.com/requests/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 2846bbca9ed5bd4c12ace11863c63d605684a5d327235ba95ff63b856bfb9e0c
 
 build:
   number: 0
-  noarch: python
-  script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
@@ -21,7 +20,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
     - cryptography >=1.3
     - pyspnego
     - requests >=1.1.0


### PR DESCRIPTION
>  ## ☆ Requests-kerberos 0.15.0  ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5862) 
[Upstream](https://github.com/requests/requests-kerberos/tree/v0.15.0)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Added skip to python versions less than 3.8
